### PR TITLE
fix: make prompt explicit

### DIFF
--- a/client.go
+++ b/client.go
@@ -210,7 +210,7 @@ func (c *client) Confirm(ctx context.Context, resp AuthResponse) error {
 }
 
 func (c *client) PromptResponse(ctx context.Context, resp PromptResponse) error {
-	_, err := c.runBasicCommand(ctx, "prompt-response/"+resp.ID, resp.Response)
+	_, err := c.runBasicCommand(ctx, "prompt-response/"+resp.ID, resp.Responses)
 	return err
 }
 

--- a/frame.go
+++ b/frame.go
@@ -1,6 +1,9 @@
 package gptscript
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type ToolCategory string
 
@@ -102,4 +105,10 @@ type PromptFrame struct {
 	Message   string    `json:"message,omitempty"`
 	Fields    []string  `json:"fields,omitempty"`
 	Sensitive bool      `json:"sensitive,omitempty"`
+}
+
+func (p *PromptFrame) String() string {
+	return fmt.Sprintf(`Message: %s
+Fields: %v
+Sensitive: %v`, p.Message, p.Fields, p.Sensitive)
 }

--- a/opts.go
+++ b/opts.go
@@ -10,4 +10,5 @@ type Options struct {
 	Workspace     string `json:"workspace"`
 	ChatState     string `json:"chatState"`
 	IncludeEvents bool   `json:"includeEvents"`
+	Prompt        bool   `json:"prompt"`
 }

--- a/prompt.go
+++ b/prompt.go
@@ -1,6 +1,6 @@
 package gptscript
 
 type PromptResponse struct {
-	ID       string            `json:"id,omitempty"`
-	Response map[string]string `json:"response,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	Responses map[string]string `json:"response,omitempty"`
 }


### PR DESCRIPTION
A caller must now use `prompt: true` to enable prompting of the user. This explicit opt-in ensures a caller knows they are required to handle the prompt event. If a prompt event occurs when a caller has not explicitly opted-in, then the run fails with an error.