### PR TITLE
feat: add the option to set the environment at the global level

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ When creating a `GTPScript` instance, you can pass the following global options.
 - `APIKey`: Specify an OpenAI API key for authenticating requests
 - `BaseURL`: A base URL for an OpenAI compatible API (the default is `https://api.openai.com/v1`)
 - `DefaultModel`: The default model to use for OpenAI requests
+- `Env`: Supply the environment variables. Supplying anything here means that nothing from the environment is used. The default is `os.Environ()`. Supplying `Env` at the run/evaluate level will be treated as "additional." 
 
 ## Run Options
 
@@ -43,7 +44,6 @@ As noted above, the Global Options are also available to specify here. These opt
 - `chatState`: The chat state to continue, or null to start a new chat and return the state
 - `confirm`: Prompt before running potentially dangerous commands
 - `prompt`: Allow prompting of the user
-- `env`: Extra environment variables to pass to the script in the form `KEY=VAL`
 
 ## Functions
 

--- a/gptscript.go
+++ b/gptscript.go
@@ -74,7 +74,10 @@ func NewGPTScript(opts GlobalOptions) (GPTScript, error) {
 
 		in, _ := io.Pipe()
 		serverProcess = exec.CommandContext(ctx, getCommand(), "--listen-address", serverURL, "sdkserver")
-		serverProcess.Env = append(os.Environ(), opts.toEnv()...)
+		if opts.Env == nil {
+			opts.Env = os.Environ()
+		}
+		serverProcess.Env = append(opts.Env[:], opts.toEnv()...)
 		serverProcess.Stdin = in
 
 		serverProcessCancel = func() {

--- a/opts.go
+++ b/opts.go
@@ -3,9 +3,10 @@ package gptscript
 // GlobalOptions allows specification of settings that are used for every call made.
 // These options can be overridden by the corresponding Options.
 type GlobalOptions struct {
-	OpenAIAPIKey  string `json:"APIKey"`
-	OpenAIBaseURL string `json:"BaseURL"`
-	DefaultModel  string `json:"DefaultModel"`
+	OpenAIAPIKey  string   `json:"APIKey"`
+	OpenAIBaseURL string   `json:"BaseURL"`
+	DefaultModel  string   `json:"DefaultModel"`
+	Env           []string `json:"env"`
 }
 
 func (g GlobalOptions) toEnv() []string {
@@ -27,14 +28,13 @@ func (g GlobalOptions) toEnv() []string {
 type Options struct {
 	GlobalOptions `json:",inline"`
 
-	Confirm       bool     `json:"confirm"`
-	Input         string   `json:"input"`
-	DisableCache  bool     `json:"disableCache"`
-	CacheDir      string   `json:"cacheDir"`
-	SubTool       string   `json:"subTool"`
-	Workspace     string   `json:"workspace"`
-	ChatState     string   `json:"chatState"`
-	IncludeEvents bool     `json:"includeEvents"`
-	Prompt        bool     `json:"prompt"`
-	Env           []string `json:"env"`
+	Confirm       bool   `json:"confirm"`
+	Input         string `json:"input"`
+	DisableCache  bool   `json:"disableCache"`
+	CacheDir      string `json:"cacheDir"`
+	SubTool       string `json:"subTool"`
+	Workspace     string `json:"workspace"`
+	ChatState     string `json:"chatState"`
+	IncludeEvents bool   `json:"includeEvents"`
+	Prompt        bool   `json:"prompt"`
 }

--- a/run_test.go
+++ b/run_test.go
@@ -20,7 +20,7 @@ func TestRestartingErrorRun(t *testing.T) {
 		Instructions: instructions,
 	}
 
-	run, err := g.Evaluate(context.Background(), Options{Env: []string{"EXIT_CODE=1"}, IncludeEvents: true}, tool, contextTool)
+	run, err := g.Evaluate(context.Background(), Options{GlobalOptions: GlobalOptions{Env: []string{"EXIT_CODE=1"}}, IncludeEvents: true}, tool, contextTool)
 	if err != nil {
 		t.Errorf("Error executing tool: %v", err)
 	}


### PR DESCRIPTION
Setting the environment at the global level will replace the environment variables from the system. Not specifying any environment will use os.Environ()