### PR TITLE
enhance: support credential override

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -28,13 +28,14 @@ func (g GlobalOptions) toEnv() []string {
 type Options struct {
 	GlobalOptions `json:",inline"`
 
-	Confirm       bool   `json:"confirm"`
-	Input         string `json:"input"`
-	DisableCache  bool   `json:"disableCache"`
-	CacheDir      string `json:"cacheDir"`
-	SubTool       string `json:"subTool"`
-	Workspace     string `json:"workspace"`
-	ChatState     string `json:"chatState"`
-	IncludeEvents bool   `json:"includeEvents"`
-	Prompt        bool   `json:"prompt"`
+	Confirm            bool   `json:"confirm"`
+	Input              string `json:"input"`
+	DisableCache       bool   `json:"disableCache"`
+	CacheDir           string `json:"cacheDir"`
+	SubTool            string `json:"subTool"`
+	Workspace          string `json:"workspace"`
+	ChatState          string `json:"chatState"`
+	IncludeEvents      bool   `json:"includeEvents"`
+	Prompt             bool   `json:"prompt"`
+	CredentialOverride string `json:"credentialOverride"`
 }


### PR DESCRIPTION
Enable users to set credential overrides on `Run`.

e.g.

```go
run, err := g.Run(
  ctx,
  "./test.gpt",
  gptscript.Options{
    DisableCache:  true,
    IncludeEvents: true,
    CredentialOverride: "sys.openai:OPENAI_API_KEY",
  },
)
```

```yaml
tools: github.com/gptscript-ai/dalle-image-generation

You are an expert in image generation. Please generate a lion standing proudly in the savannah.
```

Depends on https://github.com/gptscript-ai/gptscript/pull/570

Addresses https://github.com/gptscript-ai/gptscript/issues/553 for `go-gptscript`