### PR TITLE
enhance: add functions for daemon servers for mTLS

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -25,6 +25,23 @@ func CreateServer() (*http.Server, error) {
 	return server, nil
 }
 
+// CreateServerWithMux creates a new HTTP server with TLS configured for GPTScript.
+// This function should be used when creating a new server for a daemon tool with a custom ServeMux.
+// The server should then be started with the StartServer function.
+func CreateServerWithMux(mux *http.ServeMux) (*http.Server, error) {
+	tlsConfig, err := getTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TLS config: %v", err)
+	}
+
+	server := &http.Server{
+		Addr:      fmt.Sprintf("127.0.0.1:%s", os.Getenv("PORT")),
+		TLSConfig: tlsConfig,
+		Handler:   mux,
+	}
+	return server, nil
+}
+
 // StartServer starts an HTTP server created by the CreateServer function.
 // This is for use with daemon tools.
 func StartServer(server *http.Server) error {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// CreateServer creates a new HTTP server with TLS configured for GPTScript.
+// This function should be used when creating a new server for a daemon tool.
+// The server should then be started with the StartServer function.
+func CreateServer() (*http.Server, error) {
+	tlsConfig, err := getTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TLS config: %v\n", err)
+	}
+
+	server := &http.Server{
+		Addr:      fmt.Sprintf("127.0.0.1:%s", os.Getenv("PORT")),
+		TLSConfig: tlsConfig,
+	}
+	return server, nil
+}
+
+// StartServer starts an HTTP server created by the CreateServer function.
+// This is for use with daemon tools.
+func StartServer(server *http.Server) error {
+	if err := server.ListenAndServeTLS("", ""); err != nil {
+		return fmt.Errorf("stopped serving: %v\n", err)
+	}
+	return nil
+}
+
+func getTLSConfig() (*tls.Config, error) {
+	certB64 := os.Getenv("CERT")
+	privateKeyB64 := os.Getenv("PRIVATE_KEY")
+	gptscriptCertB64 := os.Getenv("GPTSCRIPT_CERT")
+
+	if certB64 == "" {
+		return nil, fmt.Errorf("CERT not set")
+	} else if privateKeyB64 == "" {
+		return nil, fmt.Errorf("PRIVATE_KEY not set")
+	} else if gptscriptCertB64 == "" {
+		return nil, fmt.Errorf("GPTSCRIPT_CERT not set")
+	}
+
+	certBytes, err := base64.StdEncoding.DecodeString(certB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cert base64: %v\n", err)
+	}
+
+	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode private key base64: %v\n", err)
+	}
+
+	gptscriptCertBytes, err := base64.StdEncoding.DecodeString(gptscriptCertB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode gptscript cert base64: %v\n", err)
+	}
+
+	cert, err := tls.X509KeyPair(certBytes, privateKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create X509 key pair: %v\n", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(gptscriptCertBytes) {
+		return nil, fmt.Errorf("failed to append gptscript cert to pool")
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}, nil
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -15,7 +15,7 @@ import (
 func CreateServer() (*http.Server, error) {
 	tlsConfig, err := getTLSConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get TLS config: %v\n", err)
+		return nil, fmt.Errorf("failed to get TLS config: %v", err)
 	}
 
 	server := &http.Server{
@@ -29,7 +29,7 @@ func CreateServer() (*http.Server, error) {
 // This is for use with daemon tools.
 func StartServer(server *http.Server) error {
 	if err := server.ListenAndServeTLS("", ""); err != nil {
-		return fmt.Errorf("stopped serving: %v\n", err)
+		return fmt.Errorf("stopped serving: %v", err)
 	}
 	return nil
 }
@@ -49,22 +49,22 @@ func getTLSConfig() (*tls.Config, error) {
 
 	certBytes, err := base64.StdEncoding.DecodeString(certB64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode cert base64: %v\n", err)
+		return nil, fmt.Errorf("failed to decode cert base64: %v", err)
 	}
 
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyB64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode private key base64: %v\n", err)
+		return nil, fmt.Errorf("failed to decode private key base64: %v", err)
 	}
 
 	gptscriptCertBytes, err := base64.StdEncoding.DecodeString(gptscriptCertB64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode gptscript cert base64: %v\n", err)
+		return nil, fmt.Errorf("failed to decode gptscript cert base64: %v", err)
 	}
 
 	cert, err := tls.X509KeyPair(certBytes, privateKeyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create X509 key pair: %v\n", err)
+		return nil, fmt.Errorf("failed to create X509 key pair: %v", err)
 	}
 
 	pool := x509.NewCertPool()


### PR DESCRIPTION
Here is an example of what it looks like to use these functions:

```go
package main

import (
	"fmt"
	"net/http"
	"os"

	"github.com/gptscript-ai/go-gptscript/pkg/daemon"
)

func main() {
	server, err := daemon.CreateServer()
	if err != nil {
		fmt.Printf("failed to create server: %v\n", err)
		os.Exit(1)
	}

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		clientCert := r.TLS.PeerCertificates[0]
		fmt.Fprintf(w, "Hello, %s\n", clientCert.Subject.CommonName)
	})

	if err := daemon.StartServer(server); err != nil {
		fmt.Printf("failed to start server: %v\n", err)
		os.Exit(1)
	}
}
```