### PR TITLE
enhance: Add proper aborting of runs

### DIFF
--- a/gptscript.go
+++ b/gptscript.go
@@ -170,6 +170,11 @@ func (g *GPTScript) Run(ctx context.Context, toolPath string, opts Options) (*Ru
 	}).NextChat(ctx, opts.Input)
 }
 
+func (g *GPTScript) AbortRun(ctx context.Context, run *Run) error {
+	_, err := g.runBasicCommand(ctx, "abort/"+run.id, (map[string]any)(nil))
+	return err
+}
+
 type ParseOptions struct {
 	DisableCache bool
 }

--- a/run.go
+++ b/run.go
@@ -37,6 +37,7 @@ type Run struct {
 	basicCommand                      bool
 
 	program        *Program
+	id             string
 	callsLock      sync.RWMutex
 	calls          CallFrames
 	rawOutput      map[string]any
@@ -400,6 +401,7 @@ func (r *Run) request(ctx context.Context, payload any) (err error) {
 						if event.Run.Type == EventTypeRunStart {
 							r.callsLock.Lock()
 							r.program = &event.Run.Program
+							r.id = event.Run.ID
 							r.callsLock.Unlock()
 						} else if event.Run.Type == EventTypeRunFinish && event.Run.Error != "" {
 							r.state = Error


### PR DESCRIPTION
Aborting a run is different from "closing" it. Closing a run will result in an error. Aborting a run will cause it to stop at the the next available event and not return any error. Instead, the run will have its text appended with "ABORTED BY USER" and all the chat state will be preserved.